### PR TITLE
Fix the read file descriptor for sessions

### DIFF
--- a/src/update.c
+++ b/src/update.c
@@ -216,11 +216,11 @@ void poll_sessions(void)
 
 						break;
 					}
-				}
-
-				if (gtd->mud_output_len)
-				{
-					readmud(ses);
+					
+					if (gtd->mud_output_len)
+					{
+						readmud(ses);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The while loop in `poll_sessions` gets stuck on long output because the read file descriptor will always return 1 from `select`. This means that it will stay in the loop forever because `readmud(ses)` is never called unless it can go outside of the while loop – and it can't since that only happens when the file descriptor is <= 0.